### PR TITLE
Make lcl_head_time (start-time) an integer

### DIFF
--- a/class/omlBasePackage/OMLBase.java
+++ b/class/omlBasePackage/OMLBase.java
@@ -256,7 +256,7 @@ public class OMLBase {
 	private synchronized void create_head(){
 		// Take current time
 		head_time = System.currentTimeMillis();
-		float lcl_head_time = head_time/1000L;
+		int lcl_head_time = (int)(head_time/1000L);
 		String time = String.valueOf(lcl_head_time);
 		 
 		header.append("protocol: 1\n");


### PR DESCRIPTION
As a float, the conversion to string before for the start-time header
results as a representation in scientific notation. OMSP requires an
integral number of seconds since Epoch there, and the server only parses
the non-decimal part of the time, resulting in start_times in the
database order of magnitude earlier than reality.

As an int, it just works (:

Signed-off-by: Olivier Mehani olivier.mehani@nicta.com.au
